### PR TITLE
chore: publish minion-toolkit post

### DIFF
--- a/posts/pablocalofatti/2.minion-toolkit.md
+++ b/posts/pablocalofatti/2.minion-toolkit.md
@@ -1,6 +1,6 @@
 ---
 title: 'One Brain, Many Hands: Building a Parallel Task Orchestrator for AI Agents'
-published: false
+published: true
 description: 'How I built minion-toolkit: a parallel task orchestrator for Claude Code that turns one AI session into a coordinated team of workers.'
 tags: 'ai, productivity, opensource, webdev'
 cover_image: ./assets/minion-toolkit-cover.png


### PR DESCRIPTION
## Summary
- Flips `published: false` -> `published: true` in `posts/pablocalofatti/2.minion-toolkit.md`
- Publishes the **minion-toolkit** post ("One Brain, Many Hands"), whose content was merged in #159

This is the publish step of the two-stage flow: #159 merged the post as a draft, this PR makes it live on dev.to.
