### PR TITLE
post: publish Codex superapp article

### DIFF
--- a/posts/GBurgardt/codex-superapp-wrapper.md
+++ b/posts/GBurgardt/codex-superapp-wrapper.md
@@ -1,6 +1,6 @@
 ---
 title: How I Built a Personal AI super-app by Wrapping Codex App Server
-published: false
+published: true
 description: 'How Codex app-server turned a terminal AI workflow into a personal super-app with subagents, shared context, prompt improvement, and output explanations.'
 tags: 'ai, codex, agents, cli'
 cover_image: ./assets/codex-superapp-cover.png


### PR DESCRIPTION
## Summary

Publishes the existing Codex superapp DEV draft by changing `published` from `false` to `true`.

## Validation

- `npx --yes markdownlint-cli posts/GBurgardt/codex-superapp-wrapper.md`
- `git diff --check`

Only the `published` frontmatter field changed.